### PR TITLE
Logging

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --log-file - -w 4 -b 0.0.0.0:$PORT server:app
+web: gunicorn --log-level=$GUNICORN_LOG_LEVEL --log-file - -w 4 -b 0.0.0.0:$PORT server:app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -w 4 -b 0.0.0.0:$PORT server:app
+web: gunicorn --log-file - -w 4 -b 0.0.0.0:$PORT server:app

--- a/server.py
+++ b/server.py
@@ -56,3 +56,8 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+if __name__ != '__main__':
+    gunicorn_logger = logging.getLogger('gunicorn.error')
+    app.logger.handlers = gunicorn_logger.handlers
+    app.logger.setLevel(gunicorn_logger.level)


### PR DESCRIPTION
Upgrade our logging scheme (I hope). From now on, we should be able to use `app.logger` from our `server` module to do logging.

I installed Papertrail on our Heroku dynos to help.

The staging heroku app logs at debug, while the production at warning (using env variables).

cf #18 (help to debug the issue).